### PR TITLE
Add principal banner using a gallery image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.0.1",
+        "react-image-gallery": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/react-image-gallery": "^1.2.4",
         "autoprefixer": "^10.0.1",
         "eslint": "^8",
         "eslint-config-next": "14.1.0",
@@ -482,6 +485,15 @@
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-image-gallery": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-image-gallery/-/react-image-gallery-1.2.4.tgz",
+      "integrity": "sha512-H0xpmT5rlSH0qiTvcUDCPDLRBi3J3Xa4COqaDqGb7ffLFpQoPAxpZdNuKCuThhFI0xJmNnMubZiD6B3kCBHtcw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -3729,6 +3741,22 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-image-gallery": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-image-gallery/-/react-image-gallery-1.3.0.tgz",
+      "integrity": "sha512-lKnPaOzxqSdujPFyl+CkVw0j1aYoNCHk61cvr1h7aahf5aWqmPcR9YhUB4cYrt5Tn5KHDaPUzYm5/+cX9WxzaA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,22 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.1.0"
+    "react-icons": "^5.0.1",
+    "react-image-gallery": "^1.3.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-image-gallery": "^1.2.4",
     "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "14.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.0"
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
-import Image from "next/image";
+import Banner from "@/components/Banner";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1>Landing</h1>
+    <main>
+      <Banner />
     </main>
   );
 }

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { FC, useEffect, useState, useRef } from "react";
+import { FC, useRef } from "react";
+import useMobile from "@/hooks/useMobile";
 
 import "react-image-gallery/styles/css/image-gallery.css";
 import ImageGallery from "react-image-gallery";
@@ -7,7 +8,7 @@ import ImageGallery from "react-image-gallery";
 import { BsChevronCompactLeft, BsChevronCompactRight } from "react-icons/bs";
 
 const Banner: FC = () => {
-  const [isMobile, setIsMobile] = useState(false);
+  const { isMobile } = useMobile();
   const images = [
     {
       original: `/images/banner1${isMobile ? "m" : "d"}.webp`,
@@ -18,10 +19,6 @@ const Banner: FC = () => {
   ];
 
   const slideRef = useRef<ImageGallery>(null);
-
-  useEffect(() => {
-    setIsMobile(window.innerWidth <= 600);
-  }, []);
 
   return (
     <section className="max-w-f-hd mx-auto relative group">

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { FC, useEffect, useState, useRef } from "react";
+
+import "react-image-gallery/styles/css/image-gallery.css";
+import ImageGallery from "react-image-gallery";
+
+import { BsChevronCompactLeft, BsChevronCompactRight } from "react-icons/bs";
+
+const Banner: FC = () => {
+  const [isMobile, setIsMobile] = useState(false);
+  const images = [
+    {
+      original: `/images/banner1${isMobile ? "m" : "d"}.webp`,
+    },
+    {
+      original: `/images/banner2${isMobile ? "m" : "d"}.webp`,
+    },
+  ];
+
+  const slideRef = useRef<ImageGallery>(null);
+
+  useEffect(() => {
+    setIsMobile(window.innerWidth <= 600);
+  }, []);
+
+  return (
+    <section className="max-w-f-hd mx-auto relative group">
+      <ImageGallery
+        ref={slideRef}
+        items={images}
+        showFullscreenButton={false}
+        showPlayButton={false}
+        slideInterval={4000}
+        autoPlay
+        renderLeftNav={(onClick, disabled) => (
+          <button
+            onClick={onClick}
+            disabled={disabled}
+            className="hover:text-primary-lm transition-all ease-linear duration-300 absolute top-[50%] translate-y-[-50%] bg-background-lm z-10 p-2 rounded-full invisible group-hover:visible left-2 opacity-80"
+          >
+            <BsChevronCompactLeft size={31} />
+          </button>
+        )}
+        renderRightNav={(onClick, disabled) => (
+          <button
+            onClick={onClick}
+            disabled={disabled}
+            className="hover:text-primary-lm transition-all ease-linear duration-300 absolute top-[50%] translate-y-[-50%] bg-background-lm z-10 p-2 rounded-full invisible group-hover:visible right-2 opacity-80"
+          >
+            <BsChevronCompactRight size={31} />
+          </button>
+        )}
+        onClick={() => {
+          if (slideRef.current?.getCurrentIndex() === 1) {
+            window.open(
+              "https://actualizatucarro.mercadoshops.com.co/",
+              "_blank"
+            );
+          }
+        }}
+      />
+    </section>
+  );
+};
+export default Banner;

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+const useMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(window.innerWidth <= 600);
+  }, []);
+
+  return {
+    isMobile,
+  };
+};
+export default useMobile;


### PR DESCRIPTION
### Principal banner was added to landing

- Uses a library called react-image-gallery.
- Allows change the slide between to left and to right.
- The slide with the banner2 image on click redirects to Actualiza tu carro shop page.
- The slides changes in a 4 second time.